### PR TITLE
fix(mapping-deletion): Swallows the keymap deletion error

### DIFF
--- a/lua/lsp-overloads/handlers.lua
+++ b/lua/lsp-overloads/handlers.lua
@@ -28,9 +28,6 @@ end
 
 M.signature_handler = function(err, result, ctx, config)
   if result == nil then
-    if config and config.silent ~= true then
-      vim.notify("No signature help available")
-    end
     return
   end
 

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -112,7 +112,8 @@ end
 function Signature:remove_mappings(bufnr, mode)
   for _, buf_local_mappings in pairs(self.mappings) do
     for _, lhs in pairs(buf_local_mappings) do
-      vim.keymap.del(mode, lhs, { buffer = bufnr, silent = true })
+      -- Delete the mapping if it has been created (this may error in the case of race conditions, so swallow it)
+      pcall(vim.keymap.del, mode, lhs, { buffer = bufnr, silent = true })
 
       -- Restore the original mapping if it existed
       local original_buf_map = self.original_buf_mappings[bufnr][lhs]


### PR DESCRIPTION
- Fixes the intrusive error message that occurs if the LSP runs slowly and the closing of the signature popup occurs before the keymappings have been created for the buffer
- Also reduces frequency of notify message when signature not present