### PR TITLE
fix: wrap mapset() in nvim_buf_call

### DIFF
--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -90,7 +90,7 @@ function Signature:add_mapping(mapName, default_lhs, rhs, opts)
   -- If we haven't, get it from the list of buf keymaps and store it, so that when the signature window is destroyed later,
   -- we can restore the users original keymapping.
   if self.original_buf_mappings[self.bufnr][config_lhs] == nil and vim.fn.mapcheck(config_lhs, self.mode) ~= "" then
-    local original_map = vim.fn.maparg(config_lhs, self.mode, 0, 1)
+    local original_map = vim.fn.maparg(config_lhs, self.mode, false, true)
     self.original_buf_mappings[self.bufnr][config_lhs] = original_map
   end
 
@@ -111,7 +111,9 @@ function Signature:remove_mappings(bufnr, mode)
       local original_buf_map = self.original_buf_mappings[bufnr][lhs]
 
       if original_buf_map ~= nil then
-        vim.fn.mapset(self.mode, 0, original_buf_map)
+        vim.api.nvim_buf_call(bufnr, function()
+          vim.fn.mapset(self.mode, false, original_buf_map)
+        end)
         self.original_buf_mappings[bufnr][lhs] = nil
       end
     end


### PR DESCRIPTION
From the vim docs for `mapset()`:
```
mapset({mode}, {abbr}, {dict})                                        *mapset()*
mapset({dict})
		Restore a mapping from a dictionary, possibly returned by
		|maparg()| or |maplist()|.  A buffer mapping, when dict.buffer
		is true, is set on the current buffer; it is up to the caller
		to ensure that the intended buffer is the current buffer. This
		feature allows copying mappings from one buffer to another.
```

So since `mapset()` only restores mappings to the current buffer, previous mappings are not restored properly if the popup closes while the cursor is in another buffer. This can happen if e.g. switching to a different window while the popup is open or if the popup itself is focused and then closed with i.e. `<C-w>q`.

The fix is to temporarily set the current buffer by wrapping the call in `vim.api.nvim_buf_call`.

And then I also replaced the `0` and `1` arguments with `false` and `true` - luals was complaining about incorrect types.