### PR TITLE
fix(highlighting): active parameter highlighting

### DIFF
--- a/lua/lsp-overloads/models/signature-content.lua
+++ b/lua/lsp-overloads/models/signature-content.lua
@@ -2,6 +2,7 @@
 local SignatureContent = {
   contents = {},
   active_hl = nil,
+  label_line = 0,
 }
 
 --- Taken from https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua#L896
@@ -145,6 +146,8 @@ function SignatureContent:add_content(signature)
     end
     return
   end
+
+  self.label_line = vim.startswith(self.contents[1], "```") and 1 or 0
 end
 
 return SignatureContent

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -144,7 +144,13 @@ function Signature:create_signature_popup()
   -- so keep track of new buffer and win numbers
   local fbuf, fwin = vim.lsp.util.open_floating_preview(self.signature_content.contents, "markdown", self.config)
   if self.signature_content.active_hl then
-    vim.api.nvim_buf_add_highlight(fbuf, -1, "LspSignatureActiveParameter", self.signature_content.label_line, unpack(self.signature_content.active_hl))
+    vim.api.nvim_buf_add_highlight(
+      fbuf,
+      -1,
+      "LspSignatureActiveParameter",
+      self.signature_content.label_line,
+      unpack(self.signature_content.active_hl)
+    )
   end
   local bufnr = vim.api.nvim_get_current_buf()
 

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -144,7 +144,7 @@ function Signature:create_signature_popup()
   -- so keep track of new buffer and win numbers
   local fbuf, fwin = vim.lsp.util.open_floating_preview(self.signature_content.contents, "markdown", self.config)
   if self.signature_content.active_hl then
-    vim.api.nvim_buf_add_highlight(fbuf, -1, "LspSignatureActiveParameter", 0, unpack(self.signature_content.active_hl))
+    vim.api.nvim_buf_add_highlight(fbuf, -1, "LspSignatureActiveParameter", self.signature_content.label_line, unpack(self.signature_content.active_hl))
   end
   local bufnr = vim.api.nvim_get_current_buf()
 

--- a/lua/lsp-overloads/types/signature-types.lua
+++ b/lua/lsp-overloads/types/signature-types.lua
@@ -1,6 +1,7 @@
 ---@class SignatureContent
 ---@field contents table | nil The contents of the signature
 ---@field active_hl table | nil The active highlight of the signature
+---@field label_line integer The line of the signature's label, used for highlighting
 ---@field add_content function Adds the contents of the signature to the signature content object
 
 ---@class Signature


### PR DESCRIPTION
Currently highlighting the active parameter doesn't work due to highlighting only the first line without checking.

This PR adds a field to `SignatureContext` to keep track of where the signature's label is and use it for highlighting.