### PR TITLE
Fix flicker, and various other improvements (to me)

### DIFF
--- a/lua/lsp-overloads.lua
+++ b/lua/lsp-overloads.lua
@@ -1,7 +1,7 @@
 ---@module "lsp-overloads.settings"
-local settings = require("lsp-overloads.settings")
+local settings = require('lsp-overloads.settings')
 ---@module "lsp-overloads.handlers"
-local handlers = require("lsp-overloads.handlers")
+local handlers = require('lsp-overloads.handlers')
 
 local M = {}
 
@@ -18,16 +18,16 @@ function M.setup(client, config)
 
   table.insert(clients, client)
 
-  local group = augroup("LspSignature", { clear = false })
-  vim.api.nvim_clear_autocmds({ group = group, pattern = "<buffer>" })
-  autocmd("TextChangedI", {
+  local group = augroup('LspSignature', { clear = false })
+  vim.api.nvim_clear_autocmds({ group = group, pattern = '<buffer>' })
+  autocmd('TextChangedI', {
     group = group,
-    pattern = "<buffer>",
+    pattern = '<buffer>',
     callback = function()
       -- Guard against spamming of method not supported after
       -- stopping a language server with LspStop
       if settings.current.display_automatically then
-        local active_clients = vim.lsp.get_active_clients()
+        local active_clients = vim.lsp.get_clients()
         if #active_clients < 1 then
           return
         end
@@ -36,7 +36,7 @@ function M.setup(client, config)
     end,
   })
 
-  require("lsp-overloads.api.commands")
+  require('lsp-overloads.api.commands')
 end
 
 return M

--- a/lua/lsp-overloads/handlers.lua
+++ b/lua/lsp-overloads/handlers.lua
@@ -1,13 +1,13 @@
 ---@module "lsp-overloads.settings"
-local settings = require("lsp-overloads.settings")
-local Signature = require("lsp-overloads.models.signature")
-local autocommands = require("lsp-overloads.autocommands")
-local mappings = require("lsp-overloads.mappings")
+local settings = require('lsp-overloads.settings')
+local Signature = require('lsp-overloads.models.signature')
+local autocommands = require('lsp-overloads.autocommands')
+local mappings = require('lsp-overloads.mappings')
 
 local M = {}
 
 if settings.current.ui.highlight then
-  vim.api.nvim_set_hl(0, "LspSignatureActiveParameter", settings.current.ui.highlight)
+  vim.api.nvim_set_hl(0, 'LspSignatureActiveParameter', settings.current.ui.highlight)
 end
 
 --- Helper function to prevent multiple signature popups from opening whilst entering a tuple argument.
@@ -16,16 +16,16 @@ end
 ---@return boolean Whether or not the cursor is inside a tuple
 local function check_tuple(line_to_cursor)
   -- Quick return if there are no open parens (i.e. Not in a supported function call)
-  if not line_to_cursor:match("%(") then
+  if not line_to_cursor:match('%(') then
     return true
   end
 
   local open_parens = 0
   local closed_parens = 0
-  for _ in line_to_cursor:gmatch("%(") do
+  for _ in line_to_cursor:gmatch('%(') do
     open_parens = open_parens + 1
   end
-  for _ in line_to_cursor:gmatch("%)") do
+  for _ in line_to_cursor:gmatch('%)') do
     closed_parens = closed_parens + 1
   end
 
@@ -44,13 +44,13 @@ local check_trigger_char = function(line_to_cursor, triggers)
     local current_char = line_to_cursor:sub(#line_to_cursor, #line_to_cursor)
     local prev_char = line_to_cursor:sub(#line_to_cursor - 1, #line_to_cursor - 1)
     if current_char == trigger_char then
-      if trigger_char == "," then
+      if trigger_char == ',' then
         return check_tuple(line_to_cursor)
       end
       return true
     end
-    if current_char == " " and prev_char == trigger_char then
-      if trigger_char == "," then
+    if current_char == ' ' and prev_char == trigger_char then
+      if trigger_char == ',' then
         return check_tuple(line_to_cursor)
       end
       return true
@@ -61,6 +61,7 @@ end
 
 M.signature_handler = function(err, result, ctx, config)
   if result == nil then
+    M.curent_signature = nil
     return
   end
 
@@ -68,8 +69,9 @@ M.signature_handler = function(err, result, ctx, config)
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then
     if config and config.silent ~= true then
-      vim.notify("No signature help available")
+      vim.notify('No signature help available')
     end
+    M.curent_signature = nil
     return
   end
 
@@ -82,6 +84,7 @@ M.signature_handler = function(err, result, ctx, config)
 
   autocommands.setup_signature_augroup(signature)
   mappings.add_signature_mappings(signature)
+  M.curent_signature = signature
 end
 
 --- Opens the signature help popup for the current line
@@ -95,8 +98,8 @@ M.open_signature = function(clients, bypass_trigger)
     local triggers = client.server_capabilities.signatureHelpProvider.triggerCharacters
 
     -- csharp has wrong trigger chars for some odd reason
-    if client.name == "csharp" then
-      triggers = { "(", "," }
+    if client.name == 'csharp' then
+      triggers = { '(', ',' }
     end
 
     local pos = vim.api.nvim_win_get_cursor(0)
@@ -112,7 +115,7 @@ M.open_signature = function(clients, bypass_trigger)
     local params = vim.lsp.util.make_position_params()
     vim.lsp.buf_request(
       0,
-      "textDocument/signatureHelp",
+      'textDocument/signatureHelp',
       params,
       vim.lsp.with(M.signature_handler, {
         border = settings.current.ui.border,
@@ -131,6 +134,13 @@ M.open_signature = function(clients, bypass_trigger)
         floating_window_above_cur_line = settings.current.ui.floating_window_above_cur_line,
       })
     )
+  else
+    if M.curent_signature then
+      local current_line = vim.api.nvim_get_current_line()
+      if not current_line:find('%(') then
+        M.curent_signature:close_signature_popup()
+      end
+    end
   end
 end
 

--- a/lua/lsp-overloads/mappings.lua
+++ b/lua/lsp-overloads/mappings.lua
@@ -1,5 +1,5 @@
-local settings = require("lsp-overloads.settings")
-local autocommands = require("lsp-overloads.autocommands")
+local settings = require('lsp-overloads.settings')
+local autocommands = require('lsp-overloads.autocommands')
 
 local M = {}
 
@@ -19,7 +19,7 @@ local function modify_signature(opts)
 
     -- TODO: Make the variable name a constant somewhere
     -- Set this variable to indicate that the signature popup is swapping overloads, so don't delete the signature object.
-    vim.api.nvim_buf_set_var(opts.signature.bufnr, "is_swapping_overload", opts.signature.fwin)
+    vim.api.nvim_buf_set_var(opts.signature.bufnr, 'is_swapping_overload', opts.signature.fwin)
 
     opts.signature:create_signature_popup()
 
@@ -33,30 +33,30 @@ end
 
 function M.add_signature_mappings(signature)
   signature:add_mapping(
-    "sig_next",
+    'sig_next',
     settings.current.keymaps.next_signature,
     modify_signature,
     { signature = signature, sig_modifier = 1, param_modifier = 0 }
   )
   signature:add_mapping(
-    "sig_prev",
+    'sig_prev',
     settings.current.keymaps.previous_signature,
     modify_signature,
     { signature = signature, sig_modifier = -1, param_modifier = 0 }
   )
   signature:add_mapping(
-    "param_next",
+    'param_next',
     settings.current.keymaps.next_parameter,
     modify_signature,
     { signature = signature, sig_modifier = 0, param_modifier = 1 }
   )
   signature:add_mapping(
-    "param_prev",
+    'param_prev',
     settings.current.keymaps.previous_parameter,
     modify_signature,
     { signature = signature, sig_modifier = 0, param_modifier = -1 }
   )
-  signature:add_mapping("close", settings.current.keymaps.close_signature, close_signature, { signature = signature })
+  signature:add_mapping('close', settings.current.keymaps.close_signature, close_signature, { signature = signature })
 end
 
 return M

--- a/lua/lsp-overloads/models/signature-content.lua
+++ b/lua/lsp-overloads/models/signature-content.lua
@@ -32,10 +32,6 @@ local function convert_signature_help_to_markdown_lines(signature_help, ft, trig
     return
   end
   local label = signature.label
-  if ft then
-    -- wrap inside a code block so stylize_markdown can render it properly
-    label = ("```%s\n%s\n```"):format(ft, label)
-  end
   vim.list_extend(contents, vim.split(label, "\n", { plain = true, trimempty = true }))
 
   if signature.documentation then

--- a/lua/lsp-overloads/models/signature-content.lua
+++ b/lua/lsp-overloads/models/signature-content.lua
@@ -129,7 +129,8 @@ local function convert_signature_help_to_markdown_lines(signature_help, ft, trig
       end
     end
   end
-  return contents, active_hl, signature.documentation.label_line or 0
+
+  return contents, active_hl, (signature and signature.documentation) and signature.documentation.label_line or 0
 end
 
 local function trim_empty_lines(lines)

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -1,5 +1,5 @@
 ---@module "lsp-overloads.models.signature-content"
-local SignatureContent = require("lsp-overloads.models.signature-content")
+local SignatureContent = require('lsp-overloads.models.signature-content')
 
 ---@class Signature
 local Signature = {
@@ -26,7 +26,7 @@ end
 
 function Signature:update_with_lsp_response(err, ctx, config)
   self.err = err
-  self.mode = vim.api.nvim_get_mode()["mode"]
+  self.mode = vim.api.nvim_get_mode()['mode']
   self.ctx = ctx
   self.config = config
 end
@@ -90,7 +90,7 @@ function Signature:add_mapping(mapName, default_lhs, rhs, opts)
   -- Check if we have already stored the users original keymapping value before
   -- If we haven't, get it from the list of buf keymaps and store it, so that when the signature window is destroyed later,
   -- we can restore the users original keymapping.
-  if self.original_buf_mappings[self.bufnr][config_lhs] == nil and vim.fn.mapcheck(config_lhs, self.mode) ~= "" then
+  if self.original_buf_mappings[self.bufnr][config_lhs] == nil and vim.fn.mapcheck(config_lhs, self.mode) ~= '' then
     local original_map = vim.fn.maparg(config_lhs, self.mode, false, true)
     self.original_buf_mappings[self.bufnr][config_lhs] = original_map
   end
@@ -146,20 +146,20 @@ local function close_preview_window(winnr, bufnrs)
       return
     end
 
-    local augroup = "preview_window_" .. winnr
+    local augroup = 'preview_window_' .. winnr
     pcall(api.nvim_del_augroup_by_name, augroup)
     pcall(api.nvim_win_close, winnr, true)
   end)
 end
 
 local function close_preview_autocmd(events, winnr, bufnrs)
-  local augroup = api.nvim_create_augroup("preview_window_" .. winnr, {
+  local augroup = api.nvim_create_augroup('preview_window_' .. winnr, {
     clear = true,
   })
 
   -- close the preview window when entered a buffer that is not
   -- the floating window buffer or the buffer that spawned it
-  api.nvim_create_autocmd("BufEnter", {
+  api.nvim_create_autocmd('BufEnter', {
     group = augroup,
     callback = function()
       close_preview_window(winnr, bufnrs)
@@ -181,7 +181,7 @@ local function open_floating_preview(contents, syntax, opts)
   opts = opts or {}
   opts.wrap = opts.wrap ~= false -- wrapping by default
   opts.focus = opts.focus ~= false
-  opts.close_events = opts.close_events or { "CursorMoved", "CursorMovedI", "InsertCharPre" }
+  opts.close_events = opts.close_events or { 'CursorMoved', 'CursorMovedI', 'InsertCharPre' }
 
   local bufnr = api.nvim_get_current_buf()
 
@@ -190,7 +190,7 @@ local function open_floating_preview(contents, syntax, opts)
     -- Go back to previous window if we are in a focusable one
     local current_winnr = api.nvim_get_current_win()
     if npcall(api.nvim_win_get_var, current_winnr, opts.focus_id) then
-      api.nvim_command("wincmd p")
+      api.nvim_command('wincmd p')
       return bufnr, current_winnr
     end
     do
@@ -198,7 +198,7 @@ local function open_floating_preview(contents, syntax, opts)
       if win and api.nvim_win_is_valid(win) and vim.fn.pumvisible() == 0 then
         -- focus and return the existing buf, win
         api.nvim_set_current_win(win)
-        api.nvim_command("stopinsert")
+        api.nvim_command('stopinsert')
         return api.nvim_win_get_buf(win), win
       end
     end
@@ -209,7 +209,7 @@ local function open_floating_preview(contents, syntax, opts)
   local floating_winnr
   local floating_bufnr
   local modifying = false
-  local existing_winnr = npcall(api.nvim_buf_get_var, bufnr, "lsp_floating_preview")
+  local existing_winnr = npcall(api.nvim_buf_get_var, bufnr, 'lsp_floating_preview')
   if existing_winnr and api.nvim_win_is_valid(existing_winnr) then
     floating_winnr = existing_winnr
     floating_bufnr = vim.api.nvim_win_get_buf(floating_winnr)
@@ -221,7 +221,7 @@ local function open_floating_preview(contents, syntax, opts)
   end
 
   -- Set up the contents, using treesitter for markdown
-  local do_stylize = syntax == "markdown" and vim.g.syntax_on ~= nil
+  local do_stylize = syntax == 'markdown' and vim.g.syntax_on ~= nil
   if do_stylize then
     local width = vim.lsp.util._make_floating_popup_size(contents, opts)
     contents = vim.lsp.util._normalize_markdown(contents, { width = width })
@@ -234,7 +234,7 @@ local function open_floating_preview(contents, syntax, opts)
     api.nvim_buf_set_lines(floating_bufnr, 0, -1, false, contents)
   else
     -- Clean up input: trim empty lines
-    contents = vim.split(table.concat(contents, "\n"), "\n", { trimempty = true })
+    contents = vim.split(table.concat(contents, '\n'), '\n', { trimempty = true })
 
     if syntax then
       vim.bo[floating_bufnr].syntax = syntax
@@ -265,14 +265,14 @@ local function open_floating_preview(contents, syntax, opts)
   -- soft wrapping
   vim.wo[floating_winnr].wrap = opts.wrap
 
-  vim.bo[floating_bufnr].bufhidden = "wipe"
+  vim.bo[floating_bufnr].bufhidden = 'wipe'
 
   if not modifying then
     api.nvim_buf_set_keymap(
       floating_bufnr,
-      "n",
-      "q",
-      "<cmd>bdelete<cr>",
+      'n',
+      'q',
+      '<cmd>bdelete<cr>',
       { silent = true, noremap = true, nowait = true }
     )
     close_preview_autocmd(opts.close_events, floating_winnr, { floating_bufnr, bufnr })
@@ -282,7 +282,7 @@ local function open_floating_preview(contents, syntax, opts)
   if opts.focus_id then
     api.nvim_win_set_var(floating_winnr, opts.focus_id, bufnr)
   end
-  api.nvim_buf_set_var(bufnr, "lsp_floating_preview", floating_winnr)
+  api.nvim_buf_set_var(bufnr, 'lsp_floating_preview', floating_winnr)
 
   return floating_bufnr, floating_winnr
 end
@@ -303,12 +303,12 @@ function Signature:create_signature_popup()
 
   -- This will replace the existing lsp signature popup if it existsk with a new one.
   -- so keep track of new buffer and win numbers
-  local fbuf, fwin = open_floating_preview(self.signature_content.contents, "markdown", self.config)
+  local fbuf, fwin = open_floating_preview(self.signature_content.contents, 'markdown', self.config)
   if self.signature_content.active_hl then
     vim.api.nvim_buf_add_highlight(
       fbuf,
       -1,
-      "LspSignatureActiveParameter",
+      'LspSignatureActiveParameter',
       self.signature_content.label_line,
       unpack(self.signature_content.active_hl)
     )

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -291,7 +291,15 @@ function Signature:create_signature_popup()
   self.signature_content:add_content(self)
 
   local _, height = vim.lsp.util._make_floating_popup_size(self.signature_content.contents, self.config)
-  self.config.offset_y = -height - 3 -- -3 brings the bottom of the popup above the current line
+
+  local lines_above = vim.fn.winline() - 1
+  local is_lower_win_half = lines_above > math.floor(vim.fn.winheight(0) / 2)
+
+  -- If the cursor is in the lower half of the window,
+  -- the standard functionality will already offset the popup to be above the cursor, so we don't neeed to do it again.
+  if lines_above > height and not is_lower_win_half then
+    self.config.offset_y = -height - 3 -- -3 brings the bottom of the popup above the current line
+  end
 
   -- This will replace the existing lsp signature popup if it existsk with a new one.
   -- so keep track of new buffer and win numbers

--- a/lua/lsp-overloads/models/signature.lua
+++ b/lua/lsp-overloads/models/signature.lua
@@ -321,9 +321,11 @@ end
 
 function Signature:close_signature_popup()
   -- Close the window here, which will trigger the autocommand to remove the mappings and dispose of the signature object
-  vim.schedule(function()
-    vim.api.nvim_win_close(self.fwin, true)
-  end)
+  if self.fwin and api.nvim_win_is_valid(self.fwin) then
+    vim.schedule(function()
+      vim.api.nvim_win_close(self.fwin, true)
+    end)
+  end
 end
 
 return Signature


### PR DESCRIPTION
This PR fixes a flicker when re-triggering the signature window by keeping a single floating buffer open and replacing its contents, instead of always destroying and creating a new one.

As well as:

1. Auto hide the signature when deleting '('
2. Use `vim.defer_fn` to start treesitter so that the LSP popup appears faster at first, though without syntax very briefly at first until treesitter is started.
3. Uses just filetype for syntax of the function, and turns documentation into a comment, so markdown isn't used. Why? Well if I want markdown in this LSP pop up I can just do K to hover on documentation. All I'm interested in here is the active parameter location and type.
4. Always show the pop above the cursor anywhere I am in the screen, so that it never hides completion. My windows always have an extra 8 lines always available.

The code can definitely be improved, this is the first time I heavily modify a plugin.

Original code:

https://github.com/user-attachments/assets/51e34562-b9d3-4ae1-800e-ffb3f99d35c0



Changes from this PR:


https://github.com/user-attachments/assets/1a90fabe-ab8c-463b-9b25-bce772e043a1

